### PR TITLE
Add Location header

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
     <groupId>com.connexta.store</groupId>
     <artifactId>store-api</artifactId>
-    <version>0.1.1-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/rest/docs/pom.xml
+++ b/rest/docs/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.connexta.store</groupId>
         <artifactId>store-api-rest</artifactId>
-        <version>0.1.1-SNAPSHOT</version>
+        <version>0.2.0-SNAPSHOT</version>
     </parent>
     <name>Store API :: REST Documentation</name>
     <artifactId>store-api-rest-docs</artifactId>

--- a/rest/models/pom.xml
+++ b/rest/models/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.connexta.store</groupId>
         <artifactId>store-api-rest</artifactId>
-        <version>0.1.1-SNAPSHOT</version>
+        <version>0.2.0-SNAPSHOT</version>
     </parent>
     <name>Store API :: REST Models</name>
     <artifactId>store-api-rest-models</artifactId>

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.connexta.store</groupId>
         <artifactId>store-api</artifactId>
-        <version>0.1.1-SNAPSHOT</version>
+        <version>0.2.0-SNAPSHOT</version>
     </parent>
     <name>Store API :: REST</name>
     <artifactId>store-api-rest</artifactId>

--- a/rest/servers/pom.xml
+++ b/rest/servers/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.connexta.store</groupId>
         <artifactId>store-api-rest</artifactId>
-        <version>0.1.1-SNAPSHOT</version>
+        <version>0.2.0-SNAPSHOT</version>
     </parent>
     <name>Store API :: REST Servers</name>
     <artifactId>store-api-rest-servers</artifactId>

--- a/rest/servers/spring/pom.xml
+++ b/rest/servers/spring/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.connexta.store</groupId>
         <artifactId>store-api-rest-servers</artifactId>
-        <version>0.1.1-SNAPSHOT</version>
+        <version>0.2.0-SNAPSHOT</version>
     </parent>
     <name>Store API :: REST Spring Stubs</name>
     <artifactId>store-api-rest-spring-stubs</artifactId>

--- a/rest/specs/pom.xml
+++ b/rest/specs/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.connexta.store</groupId>
         <artifactId>store-api-rest</artifactId>
-        <version>0.1.1-SNAPSHOT</version>
+        <version>0.2.0-SNAPSHOT</version>
     </parent>
     <name>Store API :: REST Specification</name>
     <artifactId>store-api-rest-specs</artifactId>

--- a/rest/specs/src/main/filtered-resources/openapi/openapi.yaml
+++ b/rest/specs/src/main/filtered-resources/openapi/openapi.yaml
@@ -43,10 +43,12 @@ paths:
       responses:
         '201':
           description: >
-            Product created. The Location response header contains the URI of the newly created product.
+            The Product was created.
           headers:
             'Content-Version':
               $ref: '#/components/headers/ContentVersion'
+            'Location':
+              $ref: '#/components/headers/Location'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '400':
@@ -57,6 +59,7 @@ paths:
           $ref: '#/components/responses/NotImplemented'
         'default':
           $ref: '#/components/responses/DefaultError'
+  # TODO This endpoint will be replaced
   /product/{productId}/{metadataType}:
     put:
       summary: Add metadata to a Product.
@@ -89,40 +92,10 @@ paths:
       responses:
         '200':
           description: >
-            The request was successful.
+            The metadata was added to the Product.
           headers:
             'Content-Version':
               $ref: '#/components/headers/ContentVersion'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '501':
-          $ref: '#/components/responses/NotImplemented'
-        'default':
-          $ref: '#/components/responses/DefaultError'
-  /product/{productId}:
-    get:
-      summary: Get a Product.
-      description: Clients send a Product ID to retrieve the Product as a file.
-      operationId: retrieveProduct
-      tags:
-        - store
-      parameters:
-        - $ref: '#/components/parameters/ProductId'
-      responses:
-        200:
-          description: Get Product
-          content:
-            application/octet-stream:
-              schema:
-                type: string
-                format: binary
-          headers:
-            'Content-Version':
-              $ref: '#/components/headers/ContentVersion'
-        '400':
-          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -224,6 +197,15 @@ components:
         dev:
           value: '1.2.0-SNAPSHOT'
           summary: A development version
+    Location:
+      description: >
+        The URI that can be used to download the file for the Product.
+      required: true
+      schema:
+        type: string
+        format: uri
+        minLength: 1
+        maxLength: 500
   schemas:
     File:
       type: object

--- a/rest/specs/src/main/filtered-resources/openapi/openapi.yaml
+++ b/rest/specs/src/main/filtered-resources/openapi/openapi.yaml
@@ -57,8 +57,6 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '501':
           $ref: '#/components/responses/NotImplemented'
-        'default':
-          $ref: '#/components/responses/DefaultError'
   # TODO This endpoint will be replaced
   /product/{productId}/{metadataType}:
     put:
@@ -102,8 +100,6 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '501':
           $ref: '#/components/responses/NotImplemented'
-        'default':
-          $ref: '#/components/responses/DefaultError'
 
 components:
   responses:
@@ -140,16 +136,6 @@ components:
     NotImplemented:
       description: >
         The requested API version is not supported and therefore not implemented.
-      headers:
-        'Content-Version':
-          $ref: '#/components/headers/ContentVersion'
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ErrorMessage'
-    DefaultError:
-      description: >
-        Any other possible errors not currently known.
       headers:
         'Content-Version':
           $ref: '#/components/headers/ContentVersion'


### PR DESCRIPTION
This PR adds a definition for the `Location` header returned in a `createProduct` request. The Product download endpoint was also removed because clients should not be aware of "Product ID"s.